### PR TITLE
`jive::Property` improvements

### DIFF
--- a/jive_core/geometry/jive_BoxModel.cpp
+++ b/jive_core/geometry/jive_BoxModel.cpp
@@ -4,8 +4,8 @@ namespace jive
 {
     BoxModel::BoxModel(juce::ValueTree stateSource)
         : state{ stateSource }
-        , width{ state, "width", "auto" }
-        , height{ state, "height", "auto" }
+        , width{ state, "width" }
+        , height{ state, "height" }
         , minWidth{ state, "min-width" }
         , minHeight{ state, "min-height" }
         , idealWidth{ state, "ideal-width" }
@@ -14,8 +14,15 @@ namespace jive
         , padding{ state, "padding" }
         , border{ state, "border-width" }
         , margin{ state, "margin" }
-        , isValid{ state, "box-model-valid", true }
+        , isValid{ state, "box-model-valid" }
     {
+        if (!width.exists())
+            width.setAuto();
+        if (!height.exists())
+            height.setAuto();
+        if (!isValid.exists())
+            isValid = true;
+
         componentSize = juce::Rectangle{
             calculateComponentWidth(),
             calculateComponentHeight(),

--- a/jive_core/values/jive_Property.cpp
+++ b/jive_core/values/jive_Property.cpp
@@ -14,7 +14,6 @@ public:
         testReading();
         testWriting();
         testCallback();
-        testInitialValue();
         testHereditaryValues();
         testObservations();
     }
@@ -65,24 +64,6 @@ private:
         tree.setProperty("value", 2.46f, nullptr);
 
         expect(callbackCalled);
-    }
-
-    void testInitialValue()
-    {
-        beginTest("initial value");
-
-        {
-            juce::ValueTree tree{ "Tree" };
-            jive::Property<int> value{ tree, "valueThatDoesntExist", 987 };
-
-            expect(value == 987);
-        }
-        {
-            juce::ValueTree tree{ "Tree", { { "value", 574 } } };
-            jive::Property<int> value{ tree, "value", 9226 };
-
-            expect(value == 574);
-        }
     }
 
     void testHereditaryValues()

--- a/jive_core/values/jive_Property.h
+++ b/jive_core/values/jive_Property.h
@@ -54,15 +54,6 @@ namespace jive
             }
         }
 
-        Property(juce::ValueTree sourceTree,
-                 const juce::Identifier& propertyID,
-                 const ValueType& initialValue)
-            : Property{ sourceTree, propertyID }
-        {
-            if (!exists())
-                *this = initialValue;
-        }
-
         virtual ValueType get() const
         {
             return getFrom(getRootOfInheritance());

--- a/jive_layouts/layout/gui-items/content/jive_Image.cpp
+++ b/jive_layouts/layout/gui-items/content/jive_Image.cpp
@@ -5,13 +5,16 @@ namespace jive
     Image::Image(std::unique_ptr<GuiItem> itemToDecorate)
         : GuiItemDecorator{ std::move(itemToDecorate) }
         , source{ state, "source" }
-        , placement{ state, "placement", juce::RectanglePlacement::centred }
+        , placement{ state, "placement" }
         , width{ state, "width" }
         , height{ state, "height" }
         , idealWidth{ state, "ideal-width" }
         , idealHeight{ state, "ideal-height" }
         , boxModel{ toType<CommonGuiItem>()->boxModel }
     {
+        if (!placement.exists())
+            placement = juce::RectanglePlacement::centred;
+
         source.onValueChange = [this]() {
             setChildComponent(createChildComponent());
         };

--- a/jive_layouts/layout/gui-items/content/jive_Text.cpp
+++ b/jive_layouts/layout/gui-items/content/jive_Text.cpp
@@ -6,12 +6,19 @@ namespace jive
         : GuiItemDecorator{ std::move(itemToDecorate) }
         , text{ state, "text" }
         , lineSpacing{ state, "line-spacing" }
-        , justification{ state, "justification", juce::Justification::centredLeft }
-        , wordWrap{ state, "word-wrap", juce::AttributedString::WordWrap::byWord }
-        , direction{ state, "direction", juce::AttributedString::ReadingDirection::natural }
+        , justification{ state, "justification" }
+        , wordWrap{ state, "word-wrap" }
+        , direction{ state, "direction" }
         , idealWidth{ state, "ideal-width" }
         , idealHeight{ state, "ideal-height" }
     {
+        if (!justification.exists())
+            justification = juce::Justification::centredLeft;
+        if (!wordWrap.exists())
+            wordWrap = juce::AttributedString::WordWrap::byWord;
+        if (!direction.exists())
+            direction = juce::AttributedString::ReadingDirection::natural;
+
         text.onValueChange = [this]() {
             updateTextComponent();
         };

--- a/jive_layouts/layout/gui-items/content/jive_Text.h
+++ b/jive_layouts/layout/gui-items/content/jive_Text.h
@@ -26,7 +26,7 @@ namespace jive
         void updateTextComponent();
 
         Property<juce::String> text;
-        Property<float, HereditaryValueBehaviour::inheritFromAncestors> lineSpacing;
+        Property<float, Inheritance::inheritFromAncestors> lineSpacing;
         Property<juce::Justification> justification;
         Property<juce::AttributedString::WordWrap> wordWrap;
         Property<juce::AttributedString::ReadingDirection> direction;

--- a/jive_layouts/layout/gui-items/flex/jive_FlexContainer.cpp
+++ b/jive_layouts/layout/gui-items/flex/jive_FlexContainer.cpp
@@ -4,7 +4,7 @@ namespace jive
 {
     FlexContainer::FlexContainer(std::unique_ptr<GuiItem> itemToDecorate)
         : ContainerItem{ std::move(itemToDecorate) }
-        , flexDirection{ state, "flex-direction", juce::FlexBox::Direction::column }
+        , flexDirection{ state, "flex-direction" }
         , flexWrap{ state, "flex-wrap" }
         , flexJustifyContent{ state, "justify-content" }
         , flexAlignItems{ state, "align-items" }
@@ -13,6 +13,9 @@ namespace jive
     {
         jassert(state.hasProperty("display"));
         jassert(state["display"] == juce::VariantConverter<Display>::toVar(Display::flex));
+
+        if (!flexDirection.exists())
+            flexDirection = juce::FlexBox::Direction::column;
 
         flexDirection.onValueChange = [this]() {
             layoutChanged();

--- a/jive_layouts/layout/gui-items/flex/jive_FlexItem.cpp
+++ b/jive_layouts/layout/gui-items/flex/jive_FlexItem.cpp
@@ -6,11 +6,11 @@ namespace jive
         : GuiItemDecorator{ std::move(itemToDecorate) }
         , order{ state, "order" }
         , flexGrow{ state, "flex-grow" }
-        , flexShrink{ state, "flex-shrink", 1 }
+        , flexShrink{ state, "flex-shrink" }
         , flexBasis{ state, "flex-basis" }
         , alignSelf{ state, "align-self" }
-        , width{ state, "width", "auto" }
-        , height{ state, "height", "auto" }
+        , width{ state, "width" }
+        , height{ state, "height" }
         , minWidth{ state, "min-width" }
         , minHeight{ state, "min-height" }
         , idealWidth{ state, "ideal-width" }
@@ -18,6 +18,9 @@ namespace jive
         , boxModel{ toType<CommonGuiItem>()->boxModel }
     {
         jassert(getParent() != nullptr);
+
+        if (!flexShrink.exists())
+            flexShrink = 1;
 
         const auto updateParentLayout = [this]() {
             getParent()->layOutChildren();

--- a/jive_layouts/layout/gui-items/grid/jive_GridContainer.cpp
+++ b/jive_layouts/layout/gui-items/grid/jive_GridContainer.cpp
@@ -4,21 +4,38 @@ namespace jive
 {
     GridContainer::GridContainer(std::unique_ptr<GuiItem> itemToDecorate)
         : ContainerItem(std::move(itemToDecorate))
-        , justifyItems{ state, "justify-items", juce::Grid{}.justifyItems }
-        , alignItems{ state, "align-items", juce::Grid{}.alignItems }
-        , justifyContent{ state, "justify-content", juce::Grid{}.justifyContent }
-        , alignContent{ state, "align-content", juce::Grid{}.alignContent }
-        , gridAutoFlow{ state, "grid-auto-flow", juce::Grid{}.autoFlow }
+        , justifyItems{ state, "justify-items" }
+        , alignItems{ state, "align-items" }
+        , justifyContent{ state, "justify-content" }
+        , alignContent{ state, "align-content" }
+        , gridAutoFlow{ state, "grid-auto-flow" }
         , gridTemplateColumns{ state, "grid-template-columns" }
         , gridTemplateRows{ state, "grid-template-rows" }
         , gridTemplateAreas{ state, "grid-template-areas" }
-        , gridAutoRows{ state, "grid-auto-rows", juce::Grid{}.autoRows }
-        , gridAutoColumns{ state, "grid-auto-columns", juce::Grid{}.autoColumns }
+        , gridAutoRows{ state, "grid-auto-rows" }
+        , gridAutoColumns{ state, "grid-auto-columns" }
         , gap{ state, "gap" }
         , boxModel{ toType<CommonGuiItem>()->boxModel }
     {
         jassert(state.hasProperty("display"));
         jassert(state["display"] == juce::VariantConverter<Display>::toVar(Display::grid));
+
+        static const juce::Grid defaultGrid;
+
+        if (!justifyItems.exists())
+            justifyItems = defaultGrid.justifyItems;
+        if (!alignItems.exists())
+            alignItems = defaultGrid.alignItems;
+        if (!justifyContent.exists())
+            justifyContent = defaultGrid.justifyContent;
+        if (!alignContent.exists())
+            alignContent = defaultGrid.alignContent;
+        if (!gridAutoFlow.exists())
+            gridAutoFlow = defaultGrid.autoFlow;
+        if (!gridAutoRows.exists())
+            gridAutoRows = defaultGrid.autoRows;
+        if (!gridAutoColumns.exists())
+            gridAutoColumns = defaultGrid.autoColumns;
 
         justifyItems.onValueChange = [this]() {
             layoutChanged();

--- a/jive_layouts/layout/gui-items/grid/jive_GridItem.cpp
+++ b/jive_layouts/layout/gui-items/grid/jive_GridItem.cpp
@@ -5,20 +5,37 @@ namespace jive
     GridItem::GridItem(std::unique_ptr<GuiItem> itemToDecorate)
         : GuiItemDecorator{ std::move(itemToDecorate) }
         , order{ state, "order" }
-        , justifySelf{ state, "justify-self", juce::GridItem{}.justifySelf }
-        , alignSelf{ state, "align-self", juce::GridItem{}.alignSelf }
-        , gridColumn{ state, "grid-column", juce::GridItem{}.column }
-        , gridRow{ state, "grid-row", juce::GridItem{}.row }
-        , gridArea{ state, "grid-area", juce::GridItem{}.area }
-        , maxWidth{ state, "max-width", juce::GridItem{}.maxWidth }
-        , maxHeight{ state, "max-height", juce::GridItem{}.maxHeight }
-        , width{ state, "width", "auto" }
-        , height{ state, "height", "auto" }
+        , justifySelf{ state, "justify-self" }
+        , alignSelf{ state, "align-self" }
+        , gridColumn{ state, "grid-column" }
+        , gridRow{ state, "grid-row" }
+        , gridArea{ state, "grid-area" }
+        , maxWidth{ state, "max-width" }
+        , maxHeight{ state, "max-height" }
+        , width{ state, "width" }
+        , height{ state, "height" }
         , minWidth{ state, "min-width" }
         , minHeight{ state, "min-height" }
         , boxModel{ toType<CommonGuiItem>()->boxModel }
     {
         jassert(getParent() != nullptr);
+
+        static const juce::GridItem defaultGridItem;
+
+        if (!justifySelf.exists())
+            justifySelf = defaultGridItem.justifySelf;
+        if (!alignSelf.exists())
+            alignSelf = defaultGridItem.alignSelf;
+        if (!gridColumn.exists())
+            gridColumn = defaultGridItem.column;
+        if (!gridRow.exists())
+            gridRow = defaultGridItem.row;
+        if (!gridArea.exists())
+            gridArea = defaultGridItem.area;
+        if (!maxWidth.exists())
+            maxWidth = defaultGridItem.maxWidth;
+        if (!maxHeight.exists())
+            maxHeight = defaultGridItem.maxHeight;
 
         const auto invalidateParentBoxModel = [this]() {
             getParent()->state.setProperty("is-valid", false, nullptr);

--- a/jive_layouts/layout/gui-items/jive_CommonGuiItem.cpp
+++ b/jive_layouts/layout/gui-items/jive_CommonGuiItem.cpp
@@ -10,21 +10,34 @@ namespace jive
         , id{ state, "id" }
         , description{ state, "description" }
         , tooltip{ state, "tooltip" }
-        , enabled{ state, "enabled", true }
-        , visibility{ state, "visibility", true }
+        , enabled{ state, "enabled" }
+        , visibility{ state, "visibility" }
         , alwaysOnTop{ state, "always-on-top" }
         , bufferedToImage{ state, "buffered-to-image" }
         , opaque{ state, "opaque" }
         , focusable{ state, "focusable" }
-        , clickingGrabsFocus{ state, "clicking-grabs-focus", true }
+        , clickingGrabsFocus{ state, "clicking-grabs-focus" }
         , focusOutline{ state, "focus-outline" }
         , focusOrder{ state, "focus-order" }
-        , opacity{ state, "opacity", 1.f }
-        , cursor{ state, "cursor", juce::MouseCursor::NormalCursor }
-        , display{ state, "display", Display::flex }
-        , width{ state, "width", "auto" }
-        , height{ state, "height", "auto" }
+        , opacity{ state, "opacity" }
+        , cursor{ state, "cursor" }
+        , display{ state, "display" }
+        , width{ state, "width" }
+        , height{ state, "height" }
     {
+        if (!enabled.exists())
+            enabled = true;
+        if (!visibility.exists())
+            visibility = true;
+        if (!clickingGrabsFocus.exists())
+            clickingGrabsFocus = true;
+        if (!opacity.exists())
+            opacity = 1.0f;
+        if (!cursor.exists())
+            cursor = juce::MouseCursor::NormalCursor;
+        if (!display.exists())
+            display = Display::flex;
+
         name.onValueChange = [this]() {
             component->setName(name);
         };

--- a/jive_layouts/layout/gui-items/widgets/jive_Button.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_Button.cpp
@@ -20,15 +20,24 @@ namespace jive
         , toggled{ state, "toggled" }
         , toggleOnClick{ state, "toggle-on-click" }
         , radioGroup{ state, "radio-group" }
-        , triggerEvent{ state, "trigger-event", TriggerEvent::mouseUp }
+        , triggerEvent{ state, "trigger-event" }
         , tooltip{ state, "tooltip" }
-        , flexDirection{ state, "flex-direction", juce::FlexBox::Direction::row }
-        , justifyContent{ state, "justify-content", juce::FlexBox::JustifyContent::center }
-        , padding{ state, "padding", juce::BorderSize<float>{ 0.0f, 5.0f, 0.0f, 5.0f } }
-        , minWidth{ state, "min-width", 50.0f }
-        , minHeight{ state, "min-height", 20.0f }
+        , flexDirection{ state, "flex-direction" }
+        , justifyContent{ state, "justify-content" }
+        , padding{ state, "padding" }
+        , minWidth{ state, "min-width" }
+        , minHeight{ state, "min-height" }
         , onClick{ state, "on-click" }
     {
+        if (!triggerEvent.exists())
+            triggerEvent = TriggerEvent::mouseUp;
+        if (!padding.exists())
+            padding = juce::BorderSize{ 0.0f, 5.0f, 0.0f, 5.0f };
+        if (!minWidth.exists())
+            minWidth = 50.0f;
+        if (!minHeight.exists())
+            minHeight = 20.0f;
+
         toggleable.onValueChange = [this]() {
             getButton().setToggleable(toggleable);
         };

--- a/jive_layouts/layout/gui-items/widgets/jive_ComboBox.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_ComboBox.cpp
@@ -8,7 +8,7 @@ namespace jive
         , index{ itemIndex }
         , id{ index + 1 }
         , text{ tree, "text" }
-        , enabled{ tree, "enabled", true }
+        , enabled{ tree, "enabled" }
         , selected{ tree, "selected" }
     {
         comboBox.addItem(text, id);

--- a/jive_layouts/layout/gui-items/widgets/jive_Slider.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_Slider.cpp
@@ -11,20 +11,31 @@ namespace jive
         : GuiItemDecorator{ std::move(itemToDecorate) }
         , value{ state, "value" }
         , min{ state, "min" }
-        , max{ state, "max", "1.0" }
+        , max{ state, "max" }
         , mid{ state, "mid" }
         , interval{ state, "interval" }
         , orientation{ state, "orientation" }
         , width{ state, "width" }
         , height{ state, "height" }
-        , sensitivity{ state, "sensitivity", 1.0 }
+        , sensitivity{ state, "sensitivity" }
         , isInVelocityMode{ state, "velocity-mode" }
-        , velocitySensitivity{ state, "velocity-sensitivity", 1.0 }
-        , velocityThreshold{ state, "velocity-threshold", 1 }
+        , velocitySensitivity{ state, "velocity-sensitivity" }
+        , velocityThreshold{ state, "velocity-threshold" }
         , velocityOffset{ state, "velocity-offset" }
-        , snapToMouse{ state, "snap-to-mouse", true }
+        , snapToMouse{ state, "snap-to-mouse" }
         , onChange{ state, "on-change" }
     {
+        if (!max.exists())
+            max = "1.0";
+        if (!sensitivity.exists())
+            sensitivity = 1.0;
+        if (!velocitySensitivity.exists())
+            velocitySensitivity = 1.0;
+        if (!velocityThreshold.exists())
+            velocityThreshold = 1;
+        if (!snapToMouse.exists())
+            snapToMouse = true;
+
         min.onValueChange = [this]() {
             updateRange();
         };

--- a/jive_layouts/layout/gui-items/widgets/jive_Window.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_Window.cpp
@@ -8,23 +8,46 @@ namespace jive
 {
     Window::Window(std::unique_ptr<GuiItem> itemToDecorate)
         : GuiItemDecorator{ std::move(itemToDecorate) }
-        , hasShadow{ state, "shadow", true }
-        , isNative{ state, "native", true }
-        , isResizable{ state, "resizable", true }
+        , hasShadow{ state, "shadow" }
+        , isNative{ state, "native" }
+        , isResizable{ state, "resizable" }
         , useCornerResizer{ state, "corner-resizer" }
-        , minWidth{ state, "min-width", 1.0f }
-        , minHeight{ state, "min-height", 1.0f }
-        , maxWidth{ state, "max-width", static_cast<float>(std::numeric_limits<juce::int16>::max()) }
-        , maxHeight{ state, "max-height", static_cast<float>(std::numeric_limits<juce::int16>::max()) }
-        , isDraggable{ state, "draggable", true }
+        , minWidth{ state, "min-width" }
+        , minHeight{ state, "min-height" }
+        , maxWidth{ state, "max-width" }
+        , maxHeight{ state, "max-height" }
+        , isDraggable{ state, "draggable" }
         , isFullScreen{ state, "full-screen" }
         , isMinimised{ state, "minimised" }
-        , name{ state, "name", JUCE_APPLICATION_NAME }
-        , titleBarHeight{ state, "title-bar-height", 26 }
-        , titleBarButtons{ state, "title-bar-buttons", juce::DocumentWindow::allButtons }
+        , name{ state, "name" }
+        , titleBarHeight{ state, "title-bar-height" }
+        , titleBarButtons{ state, "title-bar-buttons" }
         , width{ state, "width" }
         , height{ state, "height" }
     {
+        if (!hasShadow.exists())
+            hasShadow = true;
+        if (!isNative.exists())
+            isNative = true;
+        if (!isResizable.exists())
+            isResizable = true;
+        if (!minWidth.exists())
+            minWidth = 1.0f;
+        if (!minHeight.exists())
+            minHeight = 1.0f;
+        if (!maxWidth.exists())
+            maxWidth = static_cast<float>(std::numeric_limits<juce::int16>::max());
+        if (!maxHeight.exists())
+            maxHeight = static_cast<float>(std::numeric_limits<juce::int16>::max());
+        if (!isDraggable.exists())
+            isDraggable = true;
+        if (!name.exists())
+            name = JUCE_APPLICATION_NAME;
+        if (!titleBarHeight.exists())
+            titleBarHeight = 26;
+        if (!titleBarButtons.exists())
+            titleBarButtons = juce::DocumentWindow::allButtons;
+
         hasShadow.onValueChange = [this]() {
             getWindow().setDropShadowEnabled(hasShadow);
         };


### PR DESCRIPTION
Adds an `Accumulation` template argument that, when set to `accumulate` will accumulate all nested properties of the same name when using `get()`. E.g.

```cpp
juce::ValueTree state {
    "State",
    {
       { "foo", 123 },
    },
    {
        juce::ValueTree{
            "Child",
            {
                { "foo", 456 },
            },
        },
    },
};
jive::Property<int,
               jive::Inheritance::doNotInherit,
               jive::Accumulation::accumulate>
    foo{ state, "foo" };
foo.get(); // Returns 579.
```

---

Removes the initial-value construct from `jive::Property`. This proved to be misleading at times, it also meant that the property's value could be changed through a `const jive::Property` which felt a little odd.

To replicate the same behaviour, simply check `.exists()` on the property and set it to the desired initial value if it doesn't already exist. 