### PR TITLE
Various bug fixes

### DIFF
--- a/jive_components/widgets/jive_TextComponent.cpp
+++ b/jive_components/widgets/jive_TextComponent.cpp
@@ -115,7 +115,6 @@ namespace jive
 
         attributedString.setText(text);
 
-        attributedString.setColour(textColour);
         attributedString.setFont(font);
         attributedString.setJustification(justification);
         attributedString.setLineSpacing(lineSpacing);
@@ -124,6 +123,11 @@ namespace jive
 
         for (const auto& appendix : appendices)
             attributedString.append(appendix);
+
+        if (textColour.has_value())
+            attributedString.setColour(*textColour);
+        else if (appendices.size() == 0)
+            attributedString.setColour(juce::Colours::black);
 
         return attributedString;
     }

--- a/jive_components/widgets/jive_TextComponent.h
+++ b/jive_components/widgets/jive_TextComponent.h
@@ -45,7 +45,7 @@ namespace jive
         juce::Justification justification{ juce::Justification::topLeft };
         float lineSpacing{ 0.0f };
         juce::String text;
-        juce::Colour textColour{ juce::Colours::black };
+        std::optional<juce::Colour> textColour{ juce::Colours::black };
         juce::AttributedString::WordWrap wordWrap{ juce::AttributedString::WordWrap::byWord };
         juce::Array<juce::AttributedString> appendices;
 

--- a/jive_core/values/jive_Event.h
+++ b/jive_core/values/jive_Event.h
@@ -18,7 +18,7 @@ namespace jive
 
             callbacks.append(juce::var{
                 [weakThis = juce::WeakReference{ this }](const juce::var::NativeFunctionArgs&) {
-                    if (weakThis->onTrigger != nullptr)
+                    if (weakThis != nullptr && weakThis->onTrigger != nullptr)
                         weakThis->onTrigger();
 
                     return juce::var{};
@@ -69,8 +69,12 @@ namespace jive
         {
             const auto callback = onTrigger;
             onTrigger = nullptr;
+
+            juce::WeakReference weakThis{ this };
             trigger();
-            onTrigger = callback;
+
+            if (weakThis != nullptr)
+                weakThis->onTrigger = callback;
         }
 
         const juce::Identifier id;

--- a/jive_layouts/layout/gui-items/block/jive_BlockContainer.cpp
+++ b/jive_layouts/layout/gui-items/block/jive_BlockContainer.cpp
@@ -11,6 +11,8 @@ namespace jive
 
     void BlockContainer::layOutChildren()
     {
+        GuiItemDecorator::layOutChildren();
+
         for (auto child : getChildren())
         {
             auto& blockItem = *dynamic_cast<GuiItemDecorator&>(*child).toType<BlockItem>();

--- a/jive_layouts/layout/gui-items/content/jive_Image.cpp
+++ b/jive_layouts/layout/gui-items/content/jive_Image.cpp
@@ -243,14 +243,6 @@ public:
     }
 
 private:
-    std::unique_ptr<jive::Image> createImage(juce::ValueTree tree)
-    {
-        jive::Interpreter interpreter;
-        return std::unique_ptr<jive::Image>{
-            dynamic_cast<jive::Image*>(interpreter.interpret(tree).release()),
-        };
-    }
-
     void testImage()
     {
         beginTest("image");
@@ -263,16 +255,19 @@ private:
                     { "height", 333 },
                 }
             };
-            auto item = createImage(tree);
-            expect(item->getDrawable().isEmpty());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& imageItem = *dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                   .toType<jive::Image>();
+            expect(imageItem.getDrawable().isEmpty());
 
             const juce::Image image{ juce::Image::ARGB, 120, 40, true };
             tree.setProperty("source", juce::VariantConverter<juce::Image>::toVar(image), nullptr);
-            expect(item->getDrawable().isImage());
-            expectEquals(static_cast<juce::Image>(item->getDrawable()).getWidth(), image.getWidth());
-            expectEquals(static_cast<juce::Image>(item->getDrawable()).getHeight(), image.getHeight());
-            expect(static_cast<juce::Image>(item->getDrawable()).getPixelData() == image.getPixelData());
-            expect(dynamic_cast<juce::ImageComponent*>(item->getComponent()->getChildComponent(0)) != nullptr);
+            expect(imageItem.getDrawable().isImage());
+            expectEquals(static_cast<juce::Image>(imageItem.getDrawable()).getWidth(), image.getWidth());
+            expectEquals(static_cast<juce::Image>(imageItem.getDrawable()).getHeight(), image.getHeight());
+            expect(static_cast<juce::Image>(imageItem.getDrawable()).getPixelData() == image.getPixelData());
+            expect(dynamic_cast<juce::ImageComponent*>(imageItem.getComponent()->getChildComponent(0)) != nullptr);
         }
         {
             const juce::Image image{ juce::Image::ARGB, 643, 111, true };
@@ -284,11 +279,14 @@ private:
                     { "source", juce::VariantConverter<juce::Image>::toVar(image) },
                 },
             };
-            auto item = createImage(tree);
-            expect(item->getDrawable().isImage());
-            expectEquals(static_cast<juce::Image>(item->getDrawable()).getWidth(), image.getWidth());
-            expectEquals(static_cast<juce::Image>(item->getDrawable()).getHeight(), image.getHeight());
-            expect(static_cast<juce::Image>(item->getDrawable()).getPixelData() == image.getPixelData());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& imageItem = *dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                   .toType<jive::Image>();
+            expect(imageItem.getDrawable().isImage());
+            expectEquals(static_cast<juce::Image>(imageItem.getDrawable()).getWidth(), image.getWidth());
+            expectEquals(static_cast<juce::Image>(imageItem.getDrawable()).getHeight(), image.getHeight());
+            expect(static_cast<juce::Image>(imageItem.getDrawable()).getPixelData() == image.getPixelData());
         }
     }
 
@@ -305,8 +303,11 @@ private:
                     { "source", juce::VariantConverter<juce::Image>::toVar(juce::Image{ juce::Image::ARGB, 51, 54, true }) },
                 },
             };
-            auto item = createImage(tree);
-            auto& image = dynamic_cast<juce::ImageComponent&>(*item->getComponent()->getChildComponent(0));
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& imageItem = *dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                   .toType<jive::Image>();
+            auto& image = dynamic_cast<juce::ImageComponent&>(*imageItem.getComponent()->getChildComponent(0));
             expect(image.getImagePlacement().testFlags(juce::RectanglePlacement::centred));
 
             tree.setProperty("placement", "top right reduce-only", nullptr);
@@ -324,8 +325,11 @@ private:
                     { "placement", "stretch fill increase-only" },
                 },
             };
-            auto item = createImage(tree);
-            auto& image = dynamic_cast<juce::ImageComponent&>(*item->getComponent()->getChildComponent(0));
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& imageItem = *dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                   .toType<jive::Image>();
+            auto& image = dynamic_cast<juce::ImageComponent&>(*imageItem.getComponent()->getChildComponent(0));
             expect(image.getImagePlacement().testFlags(juce::RectanglePlacement::stretchToFit
                                                        + juce::RectanglePlacement::fillDestination
                                                        + juce::RectanglePlacement::onlyIncreaseInSize));
@@ -390,12 +394,15 @@ private:
                     { "height", 333 },
                 }
             };
-            auto item = createImage(tree);
-            expect(item->getDrawable().isEmpty());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& imageItem = *dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                   .toType<jive::Image>();
+            expect(imageItem.getDrawable().isEmpty());
 
             tree.setProperty("source", svg, nullptr);
-            expect(item->getDrawable().isSVG());
-            expect(dynamic_cast<juce::Drawable*>(item->getComponent()->getChildComponent(0)) != nullptr);
+            expect(imageItem.getDrawable().isSVG());
+            expect(dynamic_cast<juce::Drawable*>(imageItem.getComponent()->getChildComponent(0)) != nullptr);
         }
         {
             const juce::Image image{ juce::Image::ARGB, 643, 111, true };
@@ -427,9 +434,12 @@ private:
                     },
                 },
             };
-            auto item = createImage(tree);
-            expect(item->getDrawable().isSVG());
-            expect(dynamic_cast<juce::Drawable*>(item->getComponent()->getChildComponent(0)) != nullptr);
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& imageItem = *dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                   .toType<jive::Image>();
+            expect(imageItem.getDrawable().isSVG());
+            expect(dynamic_cast<juce::Drawable*>(imageItem.getComponent()->getChildComponent(0)) != nullptr);
         }
     }
 

--- a/jive_layouts/layout/gui-items/flex/jive_FlexContainer.cpp
+++ b/jive_layouts/layout/gui-items/flex/jive_FlexContainer.cpp
@@ -36,6 +36,8 @@ namespace jive
 
     void FlexContainer::layOutChildren()
     {
+        GuiItemDecorator::layOutChildren();
+
         const auto bounds = boxModel.getContentBounds();
 
         if (bounds.getWidth() <= 0 || bounds.getHeight() <= 0)
@@ -65,9 +67,11 @@ namespace jive
             jassertfalse;
         }
 
-        const auto flex = const_cast<FlexContainer&>(*this)
-                              .buildFlexBox(constraints, LayoutStrategy::dummy);
-        juce::Point<float> extremities{ -1.0f, -1.0f };
+        auto flex = const_cast<FlexContainer&>(*this)
+                        .buildFlexBox(constraints, LayoutStrategy::dummy);
+        flex.performLayout(constraints);
+
+        juce::Point extremities{ -1.0f, -1.0f };
 
         for (const auto& flexItem : flex.items)
         {
@@ -134,9 +138,6 @@ namespace jive
             flex.justifyContent = juce::FlexBox::JustifyContent::flexStart;
             flex.alignItems = juce::FlexBox::AlignItems::flexStart;
             flex.alignContent = juce::FlexBox::AlignContent::flexStart;
-
-            flex.performLayout(bounds);
-
             break;
         default:
             jassertfalse;
@@ -169,13 +170,6 @@ public:
     }
 
 private:
-    std::unique_ptr<jive::FlexContainer> createFlexContainer(juce::ValueTree tree)
-    {
-        jive::Interpreter interpreter;
-
-        return std::unique_ptr<jive::FlexContainer>(dynamic_cast<jive::FlexContainer*>(interpreter.interpret(tree).release()));
-    }
-
     void testDirection()
     {
         beginTest("direction");
@@ -187,13 +181,16 @@ private:
                 { "height", 333 },
             },
         };
-        auto item = createFlexContainer(tree);
-        auto flexBox = static_cast<juce::FlexBox>(*item);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                       .toType<jive::FlexContainer>());
 
         expect(flexBox.flexDirection == juce::FlexBox::Direction::column);
 
         tree.setProperty("flex-direction", "row-reverse", nullptr);
-        flexBox = static_cast<juce::FlexBox>(*item);
+        flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                  .toType<jive::FlexContainer>());
 
         expect(flexBox.flexDirection == juce::FlexBox::Direction::rowReverse);
     }
@@ -209,13 +206,16 @@ private:
                 { "height", 333 },
             },
         };
-        auto item = createFlexContainer(tree);
-        auto flexBox = static_cast<juce::FlexBox>(*item);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                       .toType<jive::FlexContainer>());
 
         expect(flexBox.flexWrap == juce::FlexBox::Wrap::noWrap);
 
         tree.setProperty("flex-wrap", "wrap-reverse", nullptr);
-        flexBox = static_cast<juce::FlexBox>(*item);
+        flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                  .toType<jive::FlexContainer>());
 
         expect(flexBox.flexWrap == juce::FlexBox::Wrap::wrapReverse);
     }
@@ -231,13 +231,16 @@ private:
                 { "height", 333 },
             },
         };
-        auto item = createFlexContainer(tree);
-        auto flexBox = static_cast<juce::FlexBox>(*item);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                       .toType<jive::FlexContainer>());
 
         expect(flexBox.alignContent == juce::FlexBox::AlignContent::stretch);
 
         tree.setProperty("align-content", "space-between", nullptr);
-        flexBox = static_cast<juce::FlexBox>(*item);
+        flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                  .toType<jive::FlexContainer>());
 
         expect(flexBox.alignContent == juce::FlexBox::AlignContent::spaceBetween);
     }
@@ -253,13 +256,16 @@ private:
                 { "height", 333 },
             },
         };
-        auto item = createFlexContainer(tree);
-        auto flexBox = static_cast<juce::FlexBox>(*item);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                       .toType<jive::FlexContainer>());
 
         expect(flexBox.alignItems == juce::FlexBox::AlignItems::stretch);
 
         tree.setProperty("align-items", "centre", nullptr);
-        flexBox = static_cast<juce::FlexBox>(*item);
+        flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                  .toType<jive::FlexContainer>());
 
         expect(flexBox.alignItems == juce::FlexBox::AlignItems::center);
     }
@@ -275,13 +281,16 @@ private:
                 { "height", 333 },
             },
         };
-        auto item = createFlexContainer(tree);
-        auto flexBox = static_cast<juce::FlexBox>(*item);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                       .toType<jive::FlexContainer>());
 
         expect(flexBox.justifyContent == juce::FlexBox::JustifyContent::flexStart);
 
         tree.setProperty("justify-content", "centre", nullptr);
-        flexBox = static_cast<juce::FlexBox>(*item);
+        flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                  .toType<jive::FlexContainer>());
 
         expect(flexBox.justifyContent == juce::FlexBox::JustifyContent::center);
     }
@@ -297,8 +306,10 @@ private:
                 { "height", 333 },
             },
         };
-        auto item = createFlexContainer(tree);
-        auto flexBox = static_cast<juce::FlexBox>(*item);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                       .toType<jive::FlexContainer>());
 
         expect(flexBox.items.isEmpty());
 
@@ -306,7 +317,8 @@ private:
         tree.appendChild(juce::ValueTree{ "Component" }, nullptr);
         tree.appendChild(juce::ValueTree{ "Component" }, nullptr);
 
-        flexBox = static_cast<juce::FlexBox>(*item);
+        flexBox = static_cast<juce::FlexBox>(*dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                                  .toType<jive::FlexContainer>());
 
         expect(flexBox.items.size() == item->getChildren().size());
     }
@@ -331,7 +343,8 @@ private:
                 },
             },
         };
-        auto item = createFlexContainer(tree);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
         expectEquals(item->getChildren()[0]->getComponent()->getPosition(),
                      juce::Point<int>{ 0, 0 });
 

--- a/jive_layouts/layout/gui-items/grid/jive_GridContainer.cpp
+++ b/jive_layouts/layout/gui-items/grid/jive_GridContainer.cpp
@@ -74,6 +74,8 @@ namespace jive
 
     void GridContainer::layOutChildren()
     {
+        GuiItemDecorator::layOutChildren();
+
         const auto bounds = boxModel.getContentBounds().toNearestInt();
 
         if (bounds.getWidth() <= 0 || bounds.getHeight() <= 0)

--- a/jive_layouts/layout/gui-items/jive_GuiItemDecorator.cpp
+++ b/jive_layouts/layout/gui-items/jive_GuiItemDecorator.cpp
@@ -30,6 +30,16 @@ namespace jive
         return const_cast<GuiItemDecorator*>(this)->getParent();
     }
 
+    bool GuiItemDecorator::isContainer() const
+    {
+        return item->isContainer();
+    }
+
+    bool GuiItemDecorator::isContent() const
+    {
+        return item->isContent();
+    }
+
     GuiItem* GuiItemDecorator::getParent()
     {
         if (auto* parentItem = item->getParent())

--- a/jive_layouts/layout/gui-items/jive_GuiItemDecorator.h
+++ b/jive_layouts/layout/gui-items/jive_GuiItemDecorator.h
@@ -13,6 +13,9 @@ namespace jive
         const GuiItem* getParent() const override;
         GuiItem* getParent() override;
 
+        bool isContainer() const override;
+        bool isContent() const override;
+
         GuiItemDecorator& getTopLevelDecorator();
         const GuiItemDecorator& getTopLevelDecorator() const;
 

--- a/jive_layouts/layout/gui-items/widgets/jive_Button.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_Button.cpp
@@ -79,11 +79,6 @@ namespace jive
         getButton().removeListener(this);
     }
 
-    bool Button::isContainer() const
-    {
-        return false;
-    }
-
     juce::Button& Button::getButton()
     {
         return *dynamic_cast<juce::Button*>(component.get());
@@ -136,7 +131,6 @@ public:
 
     void runTest() final
     {
-        testGuiItem();
         testToggleable();
         testClickingTogglesState();
         testRadioGroup();
@@ -151,20 +145,6 @@ private:
         jive::Interpreter interpreter;
 
         return std::make_unique<jive::Button>(interpreter.interpret(tree));
-    }
-
-    void testGuiItem()
-    {
-        beginTest("gui-item");
-
-        auto item = createButton(juce::ValueTree{
-            "Button",
-            {
-                { "width", 222 },
-                { "height", 333 },
-            },
-        });
-        expect(!item->isContainer());
     }
 
     void testToggleable()

--- a/jive_layouts/layout/gui-items/widgets/jive_Button.h
+++ b/jive_layouts/layout/gui-items/widgets/jive_Button.h
@@ -16,8 +16,6 @@ namespace jive
         explicit Button(std::unique_ptr<GuiItem> itemToDecorate);
         ~Button() override;
 
-        bool isContainer() const override;
-
         juce::Button& getButton();
         const juce::Button& getButton() const;
 

--- a/jive_layouts/layout/gui-items/widgets/jive_ComboBox.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_ComboBox.cpp
@@ -180,17 +180,12 @@ public:
     }
 
 private:
-    std::unique_ptr<jive::ComboBox> createComboBox(juce::ValueTree tree)
-    {
-        jive::Interpreter interpreter;
-        return std::unique_ptr<jive::ComboBox>{ dynamic_cast<jive::ComboBox*>(interpreter.interpret(tree).release()) };
-    }
-
     void testGuiItem()
     {
         beginTest("gui-item");
 
-        auto item = createComboBox(juce::ValueTree{
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(juce::ValueTree{
             "ComboBox",
             {
                 { "width", 222 },
@@ -212,11 +207,15 @@ private:
                     { "height", 333 },
                 },
             };
-            auto item = createComboBox(tree);
-            expect(!item->getComboBox().isTextEditable());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expect(!comboBox.isTextEditable());
 
             tree.setProperty("editable", true, nullptr);
-            expect(item->getComboBox().isTextEditable());
+            expect(comboBox.isTextEditable());
         }
         {
             juce::ValueTree tree{
@@ -227,8 +226,12 @@ private:
                     { "editable", true },
                 },
             };
-            auto item = createComboBox(tree);
-            expect(item->getComboBox().isTextEditable());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expect(comboBox.isTextEditable());
         }
     }
 
@@ -244,11 +247,15 @@ private:
                     { "height", 333 },
                 },
             };
-            auto item = createComboBox(tree);
-            expect(item->getComboBox().getTooltip().isEmpty());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expect(comboBox.getTooltip().isEmpty());
 
             tree.setProperty("tooltip", "246", nullptr);
-            expectEquals(item->getComboBox().getTooltip(), juce::String{ "246" });
+            expectEquals(comboBox.getTooltip(), juce::String{ "246" });
         }
         {
             juce::ValueTree tree{
@@ -259,8 +266,12 @@ private:
                     { "tooltip", "369" },
                 },
             };
-            auto item = createComboBox(tree);
-            expectEquals(item->getComboBox().getTooltip(), juce::String{ "369" });
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expectEquals(comboBox.getTooltip(), juce::String{ "369" });
         }
     }
 
@@ -276,8 +287,12 @@ private:
                     { "height", 333 },
                 },
             };
-            auto item = createComboBox(tree);
-            expectEquals(item->getComboBox().getNumItems(), 0);
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expectEquals(comboBox.getNumItems(), 0);
 
             tree.appendChild(juce::ValueTree{
                                  "Option",
@@ -286,13 +301,13 @@ private:
                                  },
                              },
                              nullptr);
-            expectEquals(item->getComboBox().getNumItems(), 1);
-            expectEquals(item->getComboBox().getItemText(0),
+            expectEquals(comboBox.getNumItems(), 1);
+            expectEquals(comboBox.getItemText(0),
                          juce::String{ "Choose me!" });
-            expectEquals(item->getComboBox().getSelectedId(), 0);
+            expectEquals(comboBox.getSelectedId(), 0);
 
             tree.getChild(0).setProperty("selected", true, nullptr);
-            expectEquals(item->getComboBox().getSelectedId(), 1);
+            expectEquals(comboBox.getSelectedId(), 1);
 
             tree.appendChild(juce::ValueTree{
                                  "Option",
@@ -301,26 +316,26 @@ private:
                                  },
                              },
                              nullptr);
-            expectEquals(item->getComboBox().getNumItems(), 2);
-            expectEquals(item->getComboBox().getItemText(1),
+            expectEquals(comboBox.getNumItems(), 2);
+            expectEquals(comboBox.getItemText(1),
                          juce::String{ "Two" });
-            expectEquals(item->getComboBox().getSelectedId(), 1);
+            expectEquals(comboBox.getSelectedId(), 1);
 
             tree.removeChild(0, nullptr);
-            expectEquals(item->getComboBox().getNumItems(), 1);
-            expectEquals(item->getComboBox().getSelectedId(), 0);
+            expectEquals(comboBox.getNumItems(), 1);
+            expectEquals(comboBox.getSelectedId(), 0);
 
             tree.getChild(0).setProperty("enabled", false, nullptr);
-            expect(!item->getComboBox().isItemEnabled(1));
+            expect(!comboBox.isItemEnabled(1));
 
             tree.getChild(0).setProperty("text", "new text", nullptr);
-            expectEquals(item->getComboBox().getItemText(0), juce::String{ "new text" });
+            expectEquals(comboBox.getItemText(0), juce::String{ "new text" });
 
             tree.getChild(0).setProperty("selected", true, nullptr);
-            expectEquals(item->getComboBox().getSelectedId(), 1);
+            expectEquals(comboBox.getSelectedId(), 1);
 
             tree.getChild(0).setProperty("selected", false, nullptr);
-            expectEquals(item->getComboBox().getSelectedId(), 0);
+            expectEquals(comboBox.getSelectedId(), 0);
         }
         {
             juce::ValueTree tree{
@@ -346,12 +361,16 @@ private:
                     },
                 },
             };
-            auto item = createComboBox(tree);
-            expectEquals(item->getComboBox().getNumItems(), 2);
-            expectEquals(item->getComboBox().getItemText(0), juce::String{ "One" });
-            expectEquals(item->getComboBox().getItemText(1), juce::String{ "Two" });
-            expectEquals(item->getComboBox().getSelectedId(), 1);
-            expect(!item->getComboBox().isItemEnabled(2));
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expectEquals(comboBox.getNumItems(), 2);
+            expectEquals(comboBox.getItemText(0), juce::String{ "One" });
+            expectEquals(comboBox.getItemText(1), juce::String{ "Two" });
+            expectEquals(comboBox.getSelectedId(), 1);
+            expect(!comboBox.isItemEnabled(2));
         }
     }
 
@@ -367,35 +386,39 @@ private:
                     { "height", 333 },
                 },
             };
-            auto item = createComboBox(tree);
-            expectEquals(item->getComboBox().getSelectedId(), 0);
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expectEquals(comboBox.getSelectedId(), 0);
 
             tree.appendChild(juce::ValueTree{ "Option", { { "text", "1" } } }, nullptr);
             tree.appendChild(juce::ValueTree{ "Option", { { "text", "2" } } }, nullptr);
             tree.appendChild(juce::ValueTree{ "Separator" }, nullptr);
             tree.appendChild(juce::ValueTree{ "Header", { { "text", "Header" } } }, nullptr);
             tree.appendChild(juce::ValueTree{ "Option", { { "text", "3" } } }, nullptr);
-            expectEquals(item->getComboBox().getSelectedId(), 0);
+            expectEquals(comboBox.getSelectedId(), 0);
 
             tree.setProperty("selected", 0, nullptr);
-            expectEquals(item->getComboBox().getSelectedItemIndex(), 0);
+            expectEquals(comboBox.getSelectedItemIndex(), 0);
             expect(tree.getChild(0)["selected"]);
             expect(!tree.getChild(1)["selected"]);
             expect(!tree.getChild(4)["selected"]);
 
             tree.setProperty("selected", 2, nullptr);
-            expectEquals(item->getComboBox().getSelectedItemIndex(), 2);
+            expectEquals(comboBox.getSelectedItemIndex(), 2);
             expect(!tree.getChild(0)["selected"]);
             expect(!tree.getChild(1)["selected"]);
             expect(tree.getChild(4)["selected"]);
 
             tree.setProperty("selected", 100, nullptr);
-            expectEquals(item->getComboBox().getSelectedId(), 0);
+            expectEquals(comboBox.getSelectedId(), 0);
             expect(!tree.getChild(0)["selected"]);
             expect(!tree.getChild(1)["selected"]);
             expect(!tree.getChild(4)["selected"]);
 
-            item->getComboBox().setSelectedItemIndex(1, juce::NotificationType::sendNotificationSync);
+            comboBox.setSelectedItemIndex(1, juce::NotificationType::sendNotificationSync);
             expectEquals(static_cast<int>(tree["selected"]), 1);
             expect(!tree.getChild(0)["selected"]);
             expect(tree.getChild(1)["selected"]);
@@ -414,8 +437,12 @@ private:
                     juce::ValueTree{ "Option", { { "text", "Two" } } },
                 },
             };
-            auto item = createComboBox(tree);
-            expectEquals(item->getComboBox().getSelectedItemIndex(), 1);
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                                 .toType<jive::ComboBox>()
+                                 ->getComboBox();
+            expectEquals(comboBox.getSelectedItemIndex(), 1);
         }
     }
 
@@ -446,11 +473,15 @@ private:
                 },
             },
         };
-        auto item = createComboBox(tree);
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto& comboBox = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                             .toType<jive::ComboBox>()
+                             ->getComboBox();
         jive::Event onChange{ tree, "on-change" };
         expectEquals(onChange.getAssumedTriggerCount(), 0);
 
-        item->getComboBox().setSelectedId(2, juce::sendNotificationSync);
+        comboBox.setSelectedId(2, juce::sendNotificationSync);
         expectEquals(onChange.getAssumedTriggerCount(), 1);
     }
 };

--- a/jive_layouts/layout/gui-items/widgets/jive_ProgressBar.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_ProgressBar.cpp
@@ -114,7 +114,8 @@ private:
         };
         jive::Interpreter interpreter;
         auto parent = interpreter.interpret(parentState);
-        auto& progressBar = dynamic_cast<jive::ProgressBar&>(*parent->getChildren()[0]);
+        auto& progressBar = *dynamic_cast<jive::GuiItemDecorator&>(*parent->getChildren()[0])
+                                 .toType<jive::ProgressBar>();
         expect(!progressBar.isContainer());
         expectEquals(jive::BoxModel{ progressBar.state }.getWidth(), 135.0f);
         expectEquals(jive::BoxModel{ progressBar.state }.getHeight(), 20.0f);

--- a/jive_layouts/layout/gui-items/widgets/jive_Window.cpp
+++ b/jive_layouts/layout/gui-items/widgets/jive_Window.cpp
@@ -180,16 +180,6 @@ public:
     }
 
 private:
-    std::unique_ptr<jive::Window> createWindow(juce::ValueTree tree)
-    {
-        jive::Interpreter interpreter;
-
-        return std::unique_ptr<jive::Window>{
-            dynamic_cast<jive::GuiItemDecorator*>(interpreter.interpret(tree).release())
-                ->toType<jive::Window>(),
-        };
-    }
-
     void testShadow()
     {
         beginTest("shadow");
@@ -202,14 +192,18 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expect(item->getWindow().isDropShadowEnabled());
-            expect(item->getWindow().isOnDesktop());
-            expect(item->getWindow().isVisible());
-            expect(item->getWindow().isShowing());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expect(window.isDropShadowEnabled());
+            expect(window.isOnDesktop());
+            expect(window.isVisible());
+            expect(window.isShowing());
 
             tree.setProperty("shadow", false, nullptr);
-            expect(!item->getWindow().isDropShadowEnabled());
+            expect(!window.isDropShadowEnabled());
         }
         {
             juce::ValueTree tree{
@@ -220,8 +214,12 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expect(!item->getWindow().isDropShadowEnabled());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expect(!window.isDropShadowEnabled());
         }
     }
 
@@ -239,7 +237,10 @@ private:
             };
             jive::Interpreter interpreter;
             auto item = interpreter.interpret(state);
-            expect(dynamic_cast<jive::Window&>(*item).getWindow().isUsingNativeTitleBar());
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expect(window.isUsingNativeTitleBar());
             expectEquals(item->getComponent()->getWidth(), 100);
             expectEquals(item->getComponent()->getHeight(), 150);
         }
@@ -254,7 +255,9 @@ private:
             };
             jive::Interpreter interpreter;
             auto item = interpreter.interpret(state);
-            auto& window = dynamic_cast<jive::Window&>(*item).getWindow();
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
             expect(!window.isUsingNativeTitleBar());
             expectEquals(item->getComponent()->getWidth(),
                          338 - window.getBorderThickness().getLeftAndRight());
@@ -275,11 +278,15 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expect(item->getWindow().isResizable());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expect(window.isResizable());
 
             tree.setProperty("resizable", false, nullptr);
-            expect(!item->getWindow().isResizable());
+            expect(!window.isResizable());
         }
         {
             juce::ValueTree tree{
@@ -290,8 +297,12 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expect(!item->getWindow().isResizable());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expect(!window.isResizable());
         }
     }
 
@@ -307,25 +318,29 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expectEquals(item->getWindow().getConstrainer()->getMinimumWidth(), 1);
-            expectEquals(item->getWindow().getConstrainer()->getMinimumHeight(), 1);
-            expectEquals<int>(item->getWindow().getConstrainer()->getMaximumWidth(),
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expectEquals(window.getConstrainer()->getMinimumWidth(), 1);
+            expectEquals(window.getConstrainer()->getMinimumHeight(), 1);
+            expectEquals<int>(window.getConstrainer()->getMaximumWidth(),
                               std::numeric_limits<juce::int16>::max());
-            expectEquals<int>(item->getWindow().getConstrainer()->getMaximumHeight(),
+            expectEquals<int>(window.getConstrainer()->getMaximumHeight(),
                               std::numeric_limits<juce::int16>::max());
 
             tree.setProperty("min-width", 256, nullptr);
-            expectEquals(item->getWindow().getConstrainer()->getMinimumWidth(), 256);
+            expectEquals(window.getConstrainer()->getMinimumWidth(), 256);
 
             tree.setProperty("min-height", 256, nullptr);
-            expectEquals(item->getWindow().getConstrainer()->getMinimumHeight(), 256);
+            expectEquals(window.getConstrainer()->getMinimumHeight(), 256);
 
             tree.setProperty("max-width", 512, nullptr);
-            expectEquals(item->getWindow().getConstrainer()->getMaximumWidth(), 512);
+            expectEquals(window.getConstrainer()->getMaximumWidth(), 512);
 
             tree.setProperty("max-height", 512, nullptr);
-            expectEquals(item->getWindow().getConstrainer()->getMaximumHeight(), 512);
+            expectEquals(window.getConstrainer()->getMaximumHeight(), 512);
         }
         {
             juce::ValueTree tree{
@@ -339,11 +354,15 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expectEquals(item->getWindow().getConstrainer()->getMinimumWidth(), 246);
-            expectEquals(item->getWindow().getConstrainer()->getMinimumHeight(), 369);
-            expectEquals(item->getWindow().getConstrainer()->getMaximumWidth(), 1122);
-            expectEquals(item->getWindow().getConstrainer()->getMaximumHeight(), 3344);
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expectEquals(window.getConstrainer()->getMinimumWidth(), 246);
+            expectEquals(window.getConstrainer()->getMinimumHeight(), 369);
+            expectEquals(window.getConstrainer()->getMaximumWidth(), 1122);
+            expectEquals(window.getConstrainer()->getMaximumHeight(), 3344);
         }
     }
 
@@ -359,11 +378,15 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expect(item->getWindow().isDraggable());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expect(window.isDraggable());
 
             tree.setProperty("draggable", false, nullptr);
-            expect(!item->getWindow().isDraggable());
+            expect(!window.isDraggable());
         }
         {
             juce::ValueTree tree{
@@ -374,8 +397,12 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expect(!item->getWindow().isDraggable());
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expect(!window.isDraggable());
         }
     }
 
@@ -390,8 +417,12 @@ private:
                 { "height", 100 },
             },
         };
-        auto item = createWindow(tree);
-        expect(!item->getWindow().isFullScreen());
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                           .toType<jive::Window>()
+                           ->getWindow();
+        expect(!window.isFullScreen());
     }
 
     void testMinimised()
@@ -405,8 +436,12 @@ private:
                 { "height", 100 },
             },
         };
-        auto item = createWindow(tree);
-        expect(!item->getWindow().isMinimised());
+        jive::Interpreter interpreter;
+        auto item = interpreter.interpret(tree);
+        auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                           .toType<jive::Window>()
+                           ->getWindow();
+        expect(!window.isMinimised());
     }
 
     void testName()
@@ -421,11 +456,15 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expectEquals(item->getWindow().getName(), juce::String{ JUCE_APPLICATION_NAME });
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expectEquals(window.getName(), juce::String{ JUCE_APPLICATION_NAME });
 
             tree.setProperty("name", "foo", nullptr);
-            expectEquals(item->getWindow().getName(), juce::String{ "foo" });
+            expectEquals(window.getName(), juce::String{ "foo" });
         }
         {
             juce::ValueTree tree{
@@ -436,8 +475,12 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expectEquals(item->getWindow().getName(), juce::String{ "foo" });
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expectEquals(window.getName(), juce::String{ "foo" });
         }
     }
 
@@ -454,11 +497,15 @@ private:
                     { "height", 100 },
                 },
             };
-            auto item = createWindow(tree);
-            expectEquals(item->getWindow().getTitleBarHeight(), 26);
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expectEquals(window.getTitleBarHeight(), 26);
 
             tree.setProperty("title-bar-height", 32, nullptr);
-            expectEquals(item->getWindow().getTitleBarHeight(), 32);
+            expectEquals(window.getTitleBarHeight(), 32);
         }
         {
             juce::ValueTree tree{
@@ -470,8 +517,12 @@ private:
                     { "height", 222 },
                 },
             };
-            auto item = createWindow(tree);
-            expectEquals(item->getWindow().getTitleBarHeight(), 100);
+            jive::Interpreter interpreter;
+            auto item = interpreter.interpret(tree);
+            auto& window = dynamic_cast<jive::GuiItemDecorator&>(*item)
+                               .toType<jive::Window>()
+                               ->getWindow();
+            expectEquals(window.getTitleBarHeight(), 100);
         }
     }
 };

--- a/jive_style_sheets/style-sheets/jive_StyleSheet.cpp
+++ b/jive_style_sheets/style-sheets/jive_StyleSheet.cpp
@@ -560,9 +560,6 @@ private:
                           )",
                           nullptr);
         snapshot = component.createComponentSnapshot(component.getLocalBounds());
-        juce::PNGImageFormat format;
-        auto stream = juce::File::getSpecialLocation(juce::File::userDesktopDirectory).getChildFile("snapshot.png").createOutputStream();
-        format.writeImageToStream(snapshot, *stream);
         expect(withinAbsoluteError(snapshot.getPixelAt(0, 0), juce::Colour{ 0xFF161616 }, 1));
         expect(withinAbsoluteError(snapshot.getPixelAt(0, 9), juce::Colour{ 0xFF161616 }, 1));
         expect(withinAbsoluteError(snapshot.getPixelAt(9, 0), juce::Colour{ 0xFF949494 }, 1));


### PR DESCRIPTION
# 💯 

- Prevents content types being decorated with `display` behaviour, which caused layout issues with text elements.
- Check for `nullptr` in `jive::Event` when using `weakThis` in lambdas.
- Removed an annoying snapshot image that was being created in the test runner.
- Changed the way text colour is applied to text elements to fix nested text elements not displaying properly.