### PR TITLE
Various small patches

### DIFF
--- a/jive_core/algorithms/jive_Find.cpp
+++ b/jive_core/algorithms/jive_Find.cpp
@@ -2,7 +2,7 @@
 
 namespace jive
 {
-    juce::ValueTree find(juce::ValueTree& root,
+    juce::ValueTree find(const juce::ValueTree& root,
                          std::function<bool(const juce::ValueTree&)> predicate)
     {
         if (predicate == nullptr)

--- a/jive_core/algorithms/jive_Find.h
+++ b/jive_core/algorithms/jive_Find.h
@@ -2,6 +2,6 @@
 
 namespace jive
 {
-    juce::ValueTree find(juce::ValueTree& root,
+    juce::ValueTree find(const juce::ValueTree& root,
                          std::function<bool(const juce::ValueTree&)> predicate);
 } // namespace jive

--- a/jive_core/graphics/jive_Gradient.cpp
+++ b/jive_core/graphics/jive_Gradient.cpp
@@ -43,8 +43,9 @@ namespace jive
         {
             jassert(!orientation.hasValue());
 
-            gradient.point1 = startEndPoints->getStart();
-            gradient.point2 = startEndPoints->getEnd();
+            const auto bottomRightRelative = bounds.getBottomRight() - bounds.getTopLeft();
+            gradient.point1 = bounds.getTopLeft() + startEndPoints->getStart() * bottomRightRelative;
+            gradient.point2 = bounds.getTopLeft() + startEndPoints->getEnd() * bottomRightRelative;
         }
 
         return gradient;

--- a/jive_core/values/variant-converters/jive_VariantConvertion.cpp
+++ b/jive_core/values/variant-converters/jive_VariantConvertion.cpp
@@ -13,6 +13,7 @@ public:
     {
         testToVar();
         testFromVar();
+        testOptionalParsing();
     }
 
 private:
@@ -31,6 +32,14 @@ private:
 
         expectEquals(jive::fromVar<long long>(juce::var{ 808 }), 808LL);
         expectEquals(jive::fromVar<juce::Rectangle<int>>("2 4 5 6"), juce::Rectangle{ 2, 4, 6, 8 });
+    }
+
+    void testOptionalParsing()
+    {
+        beginTest("optionals");
+
+        expectEquals(jive::toVar(std::optional<int>{}), juce::var{});
+        expectEquals(jive::toVar(std::make_optional(123)), juce::var{ 123 });
     }
 };
 #endif

--- a/jive_core/values/variant-converters/jive_VariantConvertion.h
+++ b/jive_core/values/variant-converters/jive_VariantConvertion.h
@@ -9,6 +9,15 @@ namespace jive
     }
 
     template <typename T>
+    [[nodiscard]] auto toVar(const std::optional<T>& value)
+    {
+        if (value.has_value())
+            return toVar(*value);
+
+        return juce::var{};
+    }
+
+    template <typename T>
     [[nodiscard]] auto fromVar(const juce::var& value)
     {
         return juce::VariantConverter<T>::fromVar(value);

--- a/jive_style_sheets/style-sheets/jive_StyleSheet.cpp
+++ b/jive_style_sheets/style-sheets/jive_StyleSheet.cpp
@@ -373,15 +373,20 @@ namespace jive
         backgroundCanvas.setBorderWidth(borderWidth.get());
         backgroundCanvas.setBorderRadii(getBorderRadii());
 
+        const auto foreground = getForeground();
+
         if (auto* text = dynamic_cast<TextComponent*>(component.getComponent()))
         {
-            text->setTextColour(*getForeground().getColour());
+            // TextComponent uses `juce::AttributedString` which doesn't
+            // currently support anything other than solid colours!
+            jassert(foreground.getColour().has_value());
+            text->setTextColour(foreground.getColour().value_or(juce::Colours::hotpink));
             text->setFont(getFont());
         }
         if (state.getType().toString().compareIgnoreCase("svg") == 0)
         {
             state.setProperty("fill",
-                              "#" + getForeground().getColour()->toDisplayString(false),
+                              "#" + foreground.getColour()->toDisplayString(false),
                               nullptr);
         }
 


### PR DESCRIPTION
- Allow `const juce::ValueTree&` input to `jive::file()`
- Fix gradients not using relative coordinates
- Add overload to convert `std::optional<>` with `jive::toVar()`
- Add `jassert` for solid text colours