### PR TITLE
Add ID and class styling selectors

### DIFF
--- a/jive_core/values/variant-converters/jive_MiscVariantConverters.cpp
+++ b/jive_core/values/variant-converters/jive_MiscVariantConverters.cpp
@@ -116,7 +116,7 @@ namespace juce
             return result;
         }
 
-        return StringArray::fromTokens(v.toString(), " ", {});
+        return StringArray::fromTokens(v.toString(), " ,;|", "'\"");
     }
 
     var VariantConverter<StringArray>::toVar(const StringArray& array)

--- a/jive_style_sheets/README.md
+++ b/jive_style_sheets/README.md
@@ -21,6 +21,7 @@
             - [`disabled`](#disabled)
             - [Example](#example)
         - [IDs](#ids)
+        - [Classes](#classes)
         - [Child Components](#child-components)
 
 
@@ -234,6 +235,51 @@ Styles can be applied to elements with a specified `"id"` property. The style sh
         "foreground": "blue"
     }
 }
+```
+
+### Classes
+
+Styles can be applied to elements according to one or more tokens from the element's `"class"` property. The style sheet must append a `"."` to the class name it's targetting. For example:
+
+```xml
+<Button class="button-primary bg-red"></Button>
+```
+
+```json
+{
+    ".button-primary": {
+        "border-radius": 10,
+        "font-weight": "bold",
+    },
+    ".bg-red": {
+        "background": "red",
+    }
+}
+```
+
+Note that if two or more classes define the same property, the element will take the value of the _first_ element in its `"class"` list. For example:
+
+```json
+{
+    ".foo": {
+        "background": "red"
+    },
+    ".bar": {
+        "background": "green"
+    }
+}
+```
+
+This element will have a red background:
+
+```xml
+<Component class="foo bar"></Component>
+```
+
+This element will have a green background:
+
+```xml
+<Component class="bar foo"></Component>
 ```
 
 ### Child Components

--- a/jive_style_sheets/README.md
+++ b/jive_style_sheets/README.md
@@ -20,6 +20,7 @@
             - [`focus`](#focus)
             - [`disabled`](#disabled)
             - [Example](#example)
+        - [IDs](#ids)
         - [Child Components](#child-components)
 
 
@@ -215,6 +216,22 @@ Styles in the `disabled` object will be applied when the component is not enable
     },
     "disabled": {
         "background": "grey",
+    }
+}
+```
+
+### IDs
+
+Styles can be applied to elements with a specified `"id"` property. The style sheet must append a `"#"` to the ID of the element it's targetting. For example:
+
+```xml
+<Button id="save-button"></Button>
+```
+
+```json
+{
+    "#save-button": {
+        "foreground": "blue"
     }
 }
 ```


### PR DESCRIPTION
- Apply styles to elements with a specific `"id"` property.
- Apply styles to elements that include a certain name in their `"class"` property.