### PR TITLE
Stylesheet improvements

### DIFF
--- a/jive_components/canvases/jive_BackgroundCanvas.cpp
+++ b/jive_components/canvases/jive_BackgroundCanvas.cpp
@@ -94,10 +94,26 @@ namespace jive
         juce::Point<float> end{ 1.0f, 1.0f };
     };
 
+    template <typename Arithmetic>
+    [[nodiscard]] static auto limited(BorderRadii<Arithmetic> radii, Arithmetic min, Arithmetic max)
+    {
+        static_assert(std::is_arithmetic<Arithmetic>());
+
+        radii.topLeft = juce::jlimit(min, max, radii.topLeft);
+        radii.topRight = juce::jlimit(min, max, radii.topRight);
+        radii.bottomLeft = juce::jlimit(min, max, radii.bottomLeft);
+        radii.bottomRight = juce::jlimit(min, max, radii.bottomRight);
+
+        return radii;
+    }
+
     static std::array<CubicBezier, 4> getCorners(BorderRadii<float> radii,
                                                  juce::Rectangle<float> bounds)
     {
         static constexpr auto relativeControlPointOffsetForNearPerfectEllipse = 0.552f;
+
+        const auto maxRadius = juce::jmin(bounds.getWidth(), bounds.getHeight()) / 2.0f;
+        radii = limited(radii, 0.0f, maxRadius);
 
         CubicBezier topLeft;
         topLeft.start = bounds.getTopLeft().translated(0.0f, radii.topLeft);

--- a/jive_style_sheets/style-sheets/jive_StyleSheet.cpp
+++ b/jive_style_sheets/style-sheets/jive_StyleSheet.cpp
@@ -308,19 +308,6 @@ namespace jive
             return value;
         }
 
-        for (auto stateToSearch = state.getParent();
-             stateToSearch.isValid();
-             stateToSearch = stateToSearch.getParent())
-        {
-            if (auto value = ::jive::findStyleProperty<StyleSearchStrategy::childrenOnly>(stateToSearch,
-                                                                                          *selectors,
-                                                                                          propertyName);
-                value != juce::var{})
-            {
-                return value;
-            }
-        }
-
         return {};
     }
 

--- a/runners/demo-runner/source/jive_demo/gui/pages/StyleSheetsPage.h
+++ b/runners/demo-runner/source/jive_demo/gui/pages/StyleSheetsPage.h
@@ -66,7 +66,7 @@ namespace jive_demo
                                     { "foreground", "#1C3144" },
                                     { "border", "#D00000" },
                                     { "font-size", 12 },
-                                    { "border-radius", 5 },
+                                    { "border-radius", 999 },
                                 },
                             },
                             { "padding", 15 },


### PR DESCRIPTION
A couple of stylesheet fixes/improvements:

- Corner radii will now be clamped to 50% of the component's smallest dimension (i.e. 50% of the height for landscape, 50% of the width for portrait)
- Fixed properties that shouldn't be inheriting from parent style sheets doing so