### PR TITLE
Use relative file path to generate the version.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 project(JIVE
     VERSION 1.0.0
 )
-configure_file(${CMAKE_SOURCE_DIR}/version.txt.in version.txt)
+configure_file(version.txt.in version.txt)
 
 include(cmake/jive_options.cmake)
 include(cmake/jive_code_coverage.cmake)


### PR DESCRIPTION
`CMAKE_SOURCE_DIR` contains the parent project path and not the JIVE root included via `add_subdirectory`, so this happens:

```
CMake Error: File /parent_project_path/version.txt.in does not exist.
CMake Error at build/_deps/jive-src/CMakeLists.txt:5 (configure_file):
  configure_file Problem configuring file
```

Omitting `CMAKE_SOURCE_DIR` is equivalent to `CMAKE_CURRENT_LIST_DIR`.