### PR TITLE
Fix static cast in respondToPropertyChanges 

### DIFF
--- a/jive_core/values/jive_Property.h
+++ b/jive_core/values/jive_Property.h
@@ -329,7 +329,7 @@ namespace jive
 
         [[nodiscard]] auto respondToPropertyChanges(Object& objectWhosePropertyChanged) const
         {
-            return &objectWhosePropertyChanged == static_cast<Object*>(std::get<Object::ReferenceCountedPointer>(source));
+            return &objectWhosePropertyChanged == std::get<Object::ReferenceCountedPointer>(source).get();
         }
 
         [[nodiscard]] auto getRootOfInheritance() const


### PR DESCRIPTION
Made this change to make it compatible with Android Studio